### PR TITLE
Update for version 6.1.1, added new commandline options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ Talend TOS DI can be called with the following arguments:
 * **-projectName \[PROJECT NAME\]** Specify the name of the Talend project in the current workspace.
 * **-jobsToExport \[PATTERN\]** Specify with a regex the jobs to export (based on their labels).
 * **-clean** Clean the workspace.
+* **-version** Job-Version to export. If not set, the latest will be exported 
+* **-context** Context name. If not set, "Default" will be used.
 
 Example exporting all "Extractions" jobs (for instance "Extractions/fromComponentBToC"):
 
 ``
-C:\tools\talend\5.5.1\TOS_DI-win-x86_64.exe -nosplash -data C:\projects\trunk\com.bsb.myProject.transformation\src\main\talend -application com.bsb.tools.talend.export.JobExportApplication -targetFile C:\projects\trunk\com.bsb.myProject.transformation\target\Extractions.zip -projectName MY_PROJECT_TRANSFORMATION -jobsToExport "Extractions/[0-9a-zA-Z]*" -clean
+C:\tools\talend\6.1.1\TOS_DI-win-x86_64.exe -nosplash -data C:\projects\trunk\com.bsb.myProject.transformation\src\main\talend -application com.bsb.tools.talend.export.JobExportApplication -targetFile C:\projects\trunk\com.bsb.myProject.transformation\target\Extractions.zip -projectName MY_PROJECT_TRANSFORMATION -jobsToExport "Extractions/[0-9a-zA-Z]*" -clean
 ``
 
 
 ## Dependencies
 
-Dependencies declared in _pom.xml_ are based on the libraries defined in the Talend TOS DI 5.5.1 distribution (in the "plugins" directory). Dependencies can be installed on your local Maven repository with the [install-file Maven command](https://maven.apache.org/plugins/maven-install-plugin/examples/specific-local-repo.html).
+Dependencies declared in _pom.xml_ are based on the libraries defined in the Talend TOS DI 6.1.1 distribution (in the "plugins" directory). Dependencies can be installed on your local Maven repository with the [install-file Maven command](https://maven.apache.org/plugins/maven-install-plugin/examples/specific-local-repo.html).
 
 
 ## Install the plugin

--- a/pom.xml
+++ b/pom.xml
@@ -9,66 +9,126 @@
     <name>BSB :: Tools :: Talend</name>
     <description>BSB :: Tools :: Talend</description>
 
+	<repositories>
+		<repository>
+			<id>talend_open</id>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<url>http://newbuild.talend.com:8081/nexus/content/repositories/TalendOpenSourceRelease/</url>
+		</repository>
+		<repository>
+			<id>talend_open_snapshots</id>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<url>http://newbuild.talend.com:8081/nexus/content/repositories/TalendOpenSourceSnapshot/</url>
+		</repository>
+		<repository>
+        <id>swt-repo</id>
+        <url>https://swt-repo.googlecode.com/svn/repo/</url>
+    </repository>
+	</repositories>
+
+	
     <properties>
-        <talend.version>5.5.1</talend.version>
+        <talend.version>6.1.1</talend.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.eclipse.equinox</groupId>
-            <artifactId>app</artifactId>
-            <version>1.3.1.R36x_v2010080</version>
+         <dependency>
+            <groupId>org.eclipse.birt.runtime</groupId>
+            <artifactId>org.eclipse.equinox.app</artifactId>
+            <version>1.3.200.v20130910-1609</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.equinox</groupId>
-            <artifactId>common</artifactId>
-            <version>3.6.0.v20100503</version>
+            <groupId>org.eclipse.birt.runtime</groupId>
+            <artifactId>org.eclipse.equinox.common</artifactId>
+            <version>3.6.200.v20130402-1505</version>
+        </dependency>
+		<dependency>
+			<groupId>org.eclipse.core</groupId>
+			<artifactId>org.eclipse.core.jobs</artifactId>
+			<version>3.5.100</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.eclipse.jface</groupId>
+			<artifactId>org.eclipse.jface</artifactId>
+			<version>3.8.0.v20120521-2329</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.emf</groupId>
+			<artifactId>org.eclipse.emf.common</artifactId>
+			<version>2.10.1</version>
+		</dependency>
+		
+			<dependency>
+	<groupId>org.eclipse.scout.sdk.deps</groupId>
+	<artifactId>org.eclipse.ui.workbench</artifactId>
+	<version>3.107.0.v20150510-1732</version>
+</dependency>
+
+		
+		
+        <dependency>
+			<groupId>org.eclipse.core</groupId>
+			<artifactId>org.eclipse.core.resources</artifactId>
+			<version>3.7.100</version>
+		</dependency>
+		
+        <dependency>
+            <groupId>org.eclipse.swt</groupId>
+            <artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
+            <version>3.8</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.core</groupId>
-            <artifactId>org.eclipse.core.jobs</artifactId>
-            <version>3.5.1.R36x_v20100824</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.core</groupId>
-            <artifactId>org.eclipse.core.resources</artifactId>
-            <version>3.6.0.R36x_v20100825-0600</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.swt.win32.win32</groupId>
-            <artifactId>x86</artifactId>
-            <version>3.6.1.v3655c</version>
-        </dependency>
-        <dependency>
-            <groupId>org.talend.core</groupId>
+            <groupId>org.talend.studio</groupId>
             <artifactId>org.talend.core.runtime</artifactId>
             <version>${talend.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.talend.core</groupId>
+            <groupId>org.talend.studio</groupId>
             <artifactId>org.talend.core.repository</artifactId>
             <version>${talend.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.talend.core</groupId>
-            <artifactId>org.talend.core.model</artifactId>
+	
+       <dependency>
+            <groupId>org.talend.studio</groupId>
+            <artifactId>org.talend.model</artifactId>
+            <version>${talend.version}</version>
+        </dependency> 
+       <dependency>
+            <groupId>org.talend.studio</groupId>
+            <artifactId>org.talend.commons.runtime</artifactId>
             <version>${talend.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.talend.core.commons</groupId>
-            <artifactId>org.talend.core.commons.runtime</artifactId>
-            <version>${talend.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.talend</groupId>
+            <groupId>org.talend.studio</groupId>
             <artifactId>org.talend.core</artifactId>
             <version>${talend.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.talend</groupId>
+            <groupId>org.talend.studio</groupId>
             <artifactId>org.talend.repository</artifactId>
             <version>${talend.version}</version>
         </dependency>
+		 <dependency>
+            <groupId>org.eclipse.birt.runtime</groupId>
+            <artifactId>org.eclipse.emf.ecore</artifactId>
+            <version>2.10.1.v20140901-1043</version>
+        </dependency>
+		
+	
+		
+		
+		
     </dependencies>
 
     <build>

--- a/src/main/java/com/bsb/tools/talend/export/JobExportApplication.java
+++ b/src/main/java/com/bsb/tools/talend/export/JobExportApplication.java
@@ -18,7 +18,14 @@ public class JobExportApplication implements IApplication {
 
     @Override
     public Object start(IApplicationContext iApplicationContext) throws Exception {
+		String version = getParameterValue(iApplicationContext, "version");
+		if(version == null) version = "Latest";
+		String contextName = getParameterValue(iApplicationContext, "context");
+		if(contextName == null) contextName = "Default";
+		
+		
         try {
+			
             return initializeWorkspace()
                   .useProject(getMandatoryParameterValue(iApplicationContext, "projectName"))
                   .export(
@@ -29,6 +36,8 @@ public class JobExportApplication implements IApplication {
                               .needTalendLibraries()
                               .needJobScript()
                               .needDependencies()
+							  .setVersion(version)
+							  .setContext(contextName)
                   )
                   .doOnResult(
                         printIssuesOn(System.err)

--- a/src/main/java/com/bsb/tools/talend/export/JobExporter.java
+++ b/src/main/java/com/bsb/tools/talend/export/JobExporter.java
@@ -20,6 +20,7 @@ import org.talend.designer.core.ICamelDesignerCoreService;
 import org.talend.repository.model.RepositoryNode;
 import org.talend.repository.ui.wizards.exportjob.action.JobExportAction;
 import org.talend.repository.ui.wizards.exportjob.scriptsmanager.JobJavaScriptsManager;
+import org.talend.repository.ui.wizards.exportjob.scriptsmanager.JobScriptsManager;
 
 /**
  * Service responsible of exporting jobs into an archive file.
@@ -36,8 +37,9 @@ public class JobExporter {
      * on the specified choices.
      */
     JobExporter(JobExporterConfig jobExporterConfig) {
-        this.jobExporterConfig = jobExporterConfig;
-        this.manager = new JobJavaScriptsManager(jobExporterConfig.getChoices(), "Default", "All", -1, -1);
+        this.jobExporterConfig = jobExporterConfig;	
+		 //return new JobJavaScriptsManager(exportChoiceMap, contextName, launcher, statisticPort, tracePort);
+        this.manager = new JobJavaScriptsManager(jobExporterConfig.getChoices(), jobExporterConfig.getContextName(), JobScriptsManager.ALL_ENVIRONMENTS, -1, -1);
         this.manager.setDestinationPath(jobExporterConfig.getDestinationFile());
         this.manager.setTopFolderName(new File(this.manager.getDestinationPath()).getName());
     }
@@ -55,7 +57,7 @@ public class JobExporter {
             final Job job = CorePlugin.getDefault().getCodeGeneratorService().initializeTemplates();
             job.join();
 
-            final JobExportAction jobExportAction = new JobExportAction(nodes, "0.1", this.manager, null, "Job"); // TODO support versioning
+            final JobExportAction jobExportAction = new JobExportAction(nodes, this.jobExporterConfig.getVersion(), this.manager, null, "Job"); // TODO support versioning
 
             jobExportAction.run(new NullProgressMonitor());
 
@@ -87,13 +89,13 @@ public class JobExporter {
     private ITalendSynchronizer getSynchronizer(Item item) {
         ITalendSynchronizer synchronizer = CorePlugin.getDefault().getCodeGeneratorService().createRoutineSynchronizer();
 
-        if (GlobalServiceRegister.getDefault().isServiceRegistered(ICamelDesignerCoreService.class)) {
+        /*if (GlobalServiceRegister.getDefault().isServiceRegistered(ICamelDesignerCoreService.class)) {
             ICamelDesignerCoreService service = (ICamelDesignerCoreService) GlobalServiceRegister.getDefault()
                   .getService(ICamelDesignerCoreService.class);
             if (service.isInstanceofCamel(item)) {
                 synchronizer = CorePlugin.getDefault().getCodeGeneratorService().createCamelBeanSynchronizer();
             }
-        }
+        }*/
 
         return synchronizer;
     }

--- a/src/main/java/com/bsb/tools/talend/export/JobExporterConfig.java
+++ b/src/main/java/com/bsb/tools/talend/export/JobExporterConfig.java
@@ -14,11 +14,15 @@ public class JobExporterConfig {
     private final String destinationFile;
     private final Map<ExportChoice, Object> choices;
     private final String jobsToExport;
+	private String versionToExport;
+	private String contextName;
 
-    public JobExporterConfig(String destinationFile, Map<ExportChoice, Object> choices, String jobsToExport) {
+    public JobExporterConfig(String destinationFile, Map<ExportChoice, Object> choices, String jobsToExport, String version, String contextName) {
         this.destinationFile = destinationFile;
         this.choices = choices;
         this.jobsToExport = jobsToExport;
+		this.versionToExport = version;
+		this.contextName = contextName;
     }
 
     public String getDestinationFile() {
@@ -32,4 +36,13 @@ public class JobExporterConfig {
     public String getJobsToExport() {
         return jobsToExport;
     }
+	
+	public String getVersion(){
+		return versionToExport;
+	}
+	
+	public String getContextName()
+	{
+		return contextName;
+	}
 }

--- a/src/main/java/com/bsb/tools/talend/export/JobExporterConfigBuilder.java
+++ b/src/main/java/com/bsb/tools/talend/export/JobExporterConfigBuilder.java
@@ -19,22 +19,25 @@ public final class JobExporterConfigBuilder {
     private final String destinationFile;
     private final Map<ExportChoice, Object> exportChoiceMap;
     private String jobsToExport = "[0-9a-zA-Z]*";
+	private String versionToExport = "Latest";
+	private String contextName;
 
     private JobExporterConfigBuilder(String destinationFile) {
         this.destinationFile = destinationFile;
 
         this.exportChoiceMap = new EnumMap<>(ExportChoice.class);
-        this.exportChoiceMap.put(ExportChoice.needLauncher, false);
-        this.exportChoiceMap.put(ExportChoice.needSystemRoutine, false);
-        this.exportChoiceMap.put(ExportChoice.needUserRoutine, false);
-        this.exportChoiceMap.put(ExportChoice.needTalendLibraries, false);
-        this.exportChoiceMap.put(ExportChoice.needJobItem, false);
-        this.exportChoiceMap.put(ExportChoice.needJobScript, false);
-        this.exportChoiceMap.put(ExportChoice.needSourceCode, false);
-        this.exportChoiceMap.put(ExportChoice.needContext, false);
-        this.exportChoiceMap.put(ExportChoice.applyToChildren, false);
-        this.exportChoiceMap.put(ExportChoice.needDependencies, false);
-        this.exportChoiceMap.put(ExportChoice.setParameterValues, false);
+        exportChoiceMap.put(ExportChoice.needLauncher, true);
+        exportChoiceMap.put(ExportChoice.needSystemRoutine, true);
+        exportChoiceMap.put(ExportChoice.needUserRoutine, true);
+        exportChoiceMap.put(ExportChoice.needTalendLibraries, true);
+        exportChoiceMap.put(ExportChoice.needJobItem, true);
+        exportChoiceMap.put(ExportChoice.needJobScript, true);
+        exportChoiceMap.put(ExportChoice.needContext, true);
+        exportChoiceMap.put(ExportChoice.needSourceCode, false);
+        exportChoiceMap.put(ExportChoice.applyToChildren, false);
+        exportChoiceMap.put(ExportChoice.doNotCompileCode, false);
+        exportChoiceMap.put(ExportChoice.needDependencies, true);
+
     }
 
     /**
@@ -135,11 +138,34 @@ public final class JobExporterConfigBuilder {
 
         return this;
     }
+	
+	/**
+	*
+	*
+	*/
+	public JobExporterConfigBuilder setVersion(String version)
+	{
+		if(version != null && !"".equals(version.trim())) {
+			this.versionToExport = version.trim();	
+		}
+		return this;
+	}
+	
+	public JobExporterConfigBuilder setContext(String contextName)
+	{
+		if(contextName != null && !"".equals(contextName.trim()))
+		{
+			this.contextName = contextName.trim();
+		}
+		return this;
+	}
+	
+	
 
     /**
      * Builds a new jobs exporter based on the configuration specified so far.
      */
     public JobExporterConfig build() {
-        return new JobExporterConfig(destinationFile, exportChoiceMap, jobsToExport);
+        return new JobExporterConfig(destinationFile, exportChoiceMap, jobsToExport, versionToExport, contextName);
     }
 }

--- a/src/main/java/com/bsb/tools/talend/export/ProjectNodeUtils.java
+++ b/src/main/java/com/bsb/tools/talend/export/ProjectNodeUtils.java
@@ -9,7 +9,7 @@ import org.talend.repository.ProjectManager;
 import org.talend.repository.model.IRepositoryNode;
 import org.talend.repository.model.IRepositoryNode.ENodeType;
 import org.talend.repository.model.IRepositoryService;
-import org.talend.repository.model.ProjectRepositoryNode;
+import org.talend.core.repository.model.ProjectRepositoryNode;
 import org.talend.repository.model.RepositoryNode;
 
 /**

--- a/src/main/java/com/bsb/tools/talend/export/Workspace.java
+++ b/src/main/java/com/bsb/tools/talend/export/Workspace.java
@@ -22,6 +22,7 @@ import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.core.repository.model.RepositoryFactoryProvider;
 import org.talend.repository.model.RepositoryConstants;
 import org.talend.repository.ui.actions.importproject.ImportProjectsUtilities;
+import org.talend.core.model.properties.impl.PropertiesFactoryImpl;
 
 /**
  * Bunch of utility methods handling a {@link RepositoryContext}.
@@ -131,7 +132,7 @@ public final class Workspace {
      * Returns a new talend User as used by default in TOS DI.
      */
     private static User createUser() {
-        final User user = PropertiesFactory.eINSTANCE.createUser();
+        final User user = PropertiesFactoryImpl.init().createUser();
 
         user.setLogin("test@talend.com");
 

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -6,8 +6,8 @@
    version="${project.version}"
    provider-name="bsb.com">
    <requires>
-      <import plugin="org.eclipse.equinox.app" version="1.3.0"/>
-      <import plugin="org.talend.core.repository" version="5.5.1.r118616"/>
+      <import plugin="org.eclipse.equinox.app" version="1.3.200"/>
+      <import plugin="org.talend.core.repository" version="6.1.1.20151214_1327"/>
    </requires>
     <extension id="com.bsb.tools.talend.export.JobExportApplication"
                point="org.eclipse.core.runtime.applications">


### PR DESCRIPTION
Hi,
I modified the pom.xml to be able to compile for talend 6.1.1. Im not very happy with some of the eclipse dependencies, maybe somebody can find the "right" versions (1 or 2 are newer then the talend-used). 

But this is working quite fine in 6.1.1.

New Commandline Options added (see README,md) - version and context 
Also added some changes for 6.1.1 and fixed the launcher files (.bat and .sh) not beeing exported.
