### PR TITLE
Modified the Readme with "how to Build", modified pom.xml with parts from talend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ Example exporting all "Extractions" jobs (for instance "Extractions/fromComponen
 C:\tools\talend\6.1.1\TOS_DI-win-x86_64.exe -nosplash -data C:\projects\trunk\com.bsb.myProject.transformation\src\main\talend -application com.bsb.tools.talend.export.JobExportApplication -targetFile C:\projects\trunk\com.bsb.myProject.transformation\target\Extractions.zip -projectName MY_PROJECT_TRANSFORMATION -jobsToExport "Extractions/[0-9a-zA-Z]*" -clean
 ``
 
+## How to build
 
-## Dependencies
+* Checkout this repository to a local directory.
+* Make sure you can execute `mvn` on your command line.
 
-Dependencies declared in _pom.xml_ are based on the libraries defined in the Talend TOS DI 6.1.1 distribution (in the "plugins" directory). Dependencies can be installed on your local Maven repository with the [install-file Maven command](https://maven.apache.org/plugins/maven-install-plugin/examples/specific-local-repo.html).
+* The `org.talend.repository_6.1.1.20151214_1327.jar`  have to be installed in your local Maven 
+repository. 
+See [install-file Maven command](https://maven.apache.org/plugins/maven-install-plugin/examples/specific-local-repo.html)  for more details about the install-file Maven command e.g.:
+
+`mvn install:install-file -Dfile=plugins\org.talend.repository_6.1.1.20151214_1327.jar -DgroupId=org.talend.studio -DartifactId=org.talend.repository -Dversion=6.1.1 -Dpackaging=jar`
+
+ * Build the plugin with the `mvn clean install` command. 
 
 
 ## Install the plugin

--- a/mvn_local_deps.bat
+++ b/mvn_local_deps.bat
@@ -1,0 +1,1 @@
+mvn install:install-file -Dfile=plugins\org.talend.repository_6.1.1.20151214_1327.jar -DgroupId=org.talend.studio -DartifactId=org.talend.repository -Dversion=6.1.1 -Dpackaging=jar

--- a/pom.xml
+++ b/pom.xml
@@ -8,38 +8,102 @@
     <version>1.1.0-SNAPSHOT</version>
     <name>BSB :: Tools :: Talend</name>
     <description>BSB :: Tools :: Talend</description>
-
-	<repositories>
-		<repository>
-			<id>talend_open</id>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<url>http://newbuild.talend.com:8081/nexus/content/repositories/TalendOpenSourceRelease/</url>
-		</repository>
-		<repository>
-			<id>talend_open_snapshots</id>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<url>http://newbuild.talend.com:8081/nexus/content/repositories/TalendOpenSourceSnapshot/</url>
-		</repository>
-		<repository>
-        <id>swt-repo</id>
-        <url>https://swt-repo.googlecode.com/svn/repo/</url>
-    </repository>
-	</repositories>
+	<properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tycho.version>0.22.0</tycho.version>
+        <tycho-extras.version>${tycho.version}</tycho-extras.version>
+        <base.version>6.1.1</base.version>
+        <!-- osgi.version is either ${base.version}-SNAPSHOT (snapshots), ${base.version}.<suffix> (milestones), or ${base.version} (GA)-->
+        <osgi.version>6.1.1</osgi.version>
+        <!-- maven.version is either ${base.version}-SNAPSHOT (snapshots), ${base.version}-<suffix> (milestones), or ${base.version} (GA)-->
+        <maven.version>6.1.1</maven.version>
+        <repo.type>Release</repo.type>
+        <talend.nexus.host>newbuild.talend.com:8081</talend.nexus.host>
+        <talend.nexus.url>http://${talend.nexus.host}/nexus/content/repositories</talend.nexus.url>
+        <talend.nexus.p2unzip.url>http://${talend.nexus.host}/nexus/content/unzip</talend.nexus.p2unzip.url>
+        <opensourcesnapshot-unziprepo.url>${talend.nexus.p2unzip.url}/TalendP2UnzipOpenSourceSnapshot/org/talend/repo</opensourcesnapshot-unziprepo.url>
+        <opensourcerelease-unziprepo.url>${talend.nexus.p2unzip.url}/TalendP2UnzipOpenSourceRelease/org/talend/repo</opensourcerelease-unziprepo.url>
+        <eclipse-repo.url>${opensourcesnapshot-unziprepo.url}/talend-eclipse-p2-repo/6.1.0-SNAPSHOT/talend-eclipse-p2-repo-6.1.0-SNAPSHOT.zip-unzip</eclipse-repo.url>
+        <babel-repo.url>${opensourcesnapshot-unziprepo.url}/talend-babel-p2-repo/4.4.1-SNAPSHOT/talend-babel-p2-repo-4.4.1-SNAPSHOT.zip-unzip</babel-repo.url>
+        <doc-repo.url>${opensourcesnapshot-unziprepo.url}/talend-doc-p2-repo/6.1.1-SNAPSHOT/talend-doc-p2-repo-6.1.1-SNAPSHOT.zip-unzip/</doc-repo.url>
+        <bonita-open-repo.url>${opensourcerelease-unziprepo.url}/bonita-community-p2-repo/6.5.0a/bonita-community-p2-repo-6.5.0a.zip-unzip/</bonita-open-repo.url>
+        <equinox.build>org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar</equinox.build>
+        <opensourcesnapshot-repo.url>${talend.nexus.url}/TalendOpenSourceSnapshot</opensourcesnapshot-repo.url>
+        <opensourcerelease-repo.url>${talend.nexus.url}/TalendOpenSourceRelease</opensourcerelease-repo.url>
+        <tos-p2-repo.url>${talend.nexus.p2unzip.url}/TalendP2UnzipOpenSource${repo.type}/org/talend/studio/talend-tos-p2-repo/${osgi.version}/talend-tos-p2-repo-${osgi.version}.zip-unzip/</tos-p2-repo.url>
+        <tos-deps-p2-repo.url>${talend.nexus.p2unzip.url}/TalendP2UnzipOpenSource${repo.type}/org/talend/repo/dependencies.p2.tos/${maven.version}/dependencies.p2.tos-${maven.version}.zip-unzip/</tos-deps-p2-repo.url>
+        <jgit.dirtyWorkingTree.official>error</jgit.dirtyWorkingTree.official>
+        <osgi.ws>win32</osgi.ws>
+        <osgi.os>win32</osgi.os>
+        <osgi.arch>x86</osgi.arch>
+        <strictVersions>false</strictVersions>
+    </properties>
 
 	
-    <properties>
-        <talend.version>6.1.1</talend.version>
-    </properties>
+	<distributionManagement>
+        <snapshotRepository>
+            <id>talend_nexus_deployment</id>
+            <url>${opensourcesnapshot-repo.url}</url>
+            <snapshots><enabled>true</enabled></snapshots>
+            <releases><enabled>false</enabled></releases>
+        </snapshotRepository>
+        <repository>
+            <id>talend_nexus_deployment</id>
+            <url>${opensourcerelease-repo.url}</url>
+            <snapshots><enabled>false</enabled></snapshots>
+            <releases><enabled>true</enabled></releases>
+        </repository>
+    </distributionManagement>
+	
+	<repositories>
+        <repository>
+            <id>eclipse_repo</id>
+            <url>${eclipse-repo.url}</url>
+            <layout>p2</layout>
+        </repository>
+        <repository>
+            <id>babel_repo</id>
+            <url>${babel-repo.url}</url>
+            <layout>p2</layout>
+        </repository>
+        <repository>
+            <id>doc_repo</id>
+            <url>${doc-repo.url}</url>
+            <layout>p2</layout>
+        </repository>
+        <repository>
+            <id>bonita_open_repo</id>
+            <url>${bonita-open-repo.url}</url>
+            <layout>p2</layout>
+        </repository>
+		
+        <repository>
+            <id>talend_open</id>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <url>${opensourcerelease-repo.url}</url>
+        </repository>
+		
+        <repository>
+            <id>talend_open_snapshots</id>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <url>${opensourcesnapshot-repo.url}</url>
+        </repository>
+        <repository>
+            <id>tos-deps</id>
+            <url>${tos-deps-p2-repo.url}</url>
+            <layout>p2</layout>
+        </repository>
+	</repositories>
 
     <dependencies>
          <dependency>
@@ -57,79 +121,62 @@
 			<artifactId>org.eclipse.core.jobs</artifactId>
 			<version>3.5.100</version>
 		</dependency>
-		
-		<dependency>
-			<groupId>org.eclipse.jface</groupId>
-			<artifactId>org.eclipse.jface</artifactId>
-			<version>3.8.0.v20120521-2329</version>
-		</dependency>
+
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.common</artifactId>
 			<version>2.10.1</version>
 		</dependency>
 		
-			<dependency>
-	<groupId>org.eclipse.scout.sdk.deps</groupId>
-	<artifactId>org.eclipse.ui.workbench</artifactId>
-	<version>3.107.0.v20150510-1732</version>
-</dependency>
-
-		
+		<dependency>
+			<groupId>org.eclipse.scout.sdk.deps</groupId>
+			<artifactId>org.eclipse.ui.workbench</artifactId>
+			<version>3.107.0.v20150510-1732</version>
+		</dependency>
 		
         <dependency>
 			<groupId>org.eclipse.core</groupId>
 			<artifactId>org.eclipse.core.resources</artifactId>
 			<version>3.7.100</version>
 		</dependency>
-		
-        <dependency>
-            <groupId>org.eclipse.swt</groupId>
-            <artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
-            <version>3.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.talend.studio</groupId>
-            <artifactId>org.talend.core.runtime</artifactId>
-            <version>${talend.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.talend.studio</groupId>
-            <artifactId>org.talend.core.repository</artifactId>
-            <version>${talend.version}</version>
-        </dependency>
-	
-       <dependency>
-            <groupId>org.talend.studio</groupId>
-            <artifactId>org.talend.model</artifactId>
-            <version>${talend.version}</version>
-        </dependency> 
-       <dependency>
-            <groupId>org.talend.studio</groupId>
-            <artifactId>org.talend.commons.runtime</artifactId>
-            <version>${talend.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.talend.studio</groupId>
-            <artifactId>org.talend.core</artifactId>
-            <version>${talend.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.talend.studio</groupId>
-            <artifactId>org.talend.repository</artifactId>
-            <version>${talend.version}</version>
-        </dependency>
-		 <dependency>
+		<dependency>
             <groupId>org.eclipse.birt.runtime</groupId>
             <artifactId>org.eclipse.emf.ecore</artifactId>
             <version>2.10.1.v20140901-1043</version>
         </dependency>
 		
+        <dependency>
+            <groupId>org.talend.studio</groupId>
+            <artifactId>org.talend.core.runtime</artifactId>
+            <version>${base.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.talend.studio</groupId>
+            <artifactId>org.talend.core.repository</artifactId>
+            <version>${base.version}</version>
+        </dependency>
 	
-		
-		
-		
-    </dependencies>
+       <dependency>
+            <groupId>org.talend.studio</groupId>
+            <artifactId>org.talend.model</artifactId>
+            <version>${base.version}</version>
+        </dependency> 
+       <dependency>
+            <groupId>org.talend.studio</groupId>
+            <artifactId>org.talend.commons.runtime</artifactId>
+            <version>${base.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.talend.studio</groupId>
+            <artifactId>org.talend.core</artifactId>
+            <version>${base.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.talend.studio</groupId>
+            <artifactId>org.talend.repository</artifactId>
+            <version>${base.version}</version>
+        </dependency>
+</dependencies>
 
     <build>
         <resources>
@@ -141,41 +188,8 @@
                 </includes>
             </resource>
         </resources>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <finalName>bsb-talend-codegen-${project.version}</finalName>
-                    <archive>
-                        <manifestEntries>
-                            <Manifest-Version>1.0</Manifest-Version>
-                            <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
-                            <Bundle-Name>BuildJob Plug-in</Bundle-Name>
-                            <Bundle-SymbolicName>com.bsb.solife;singleton:=true</Bundle-SymbolicName>
-                            <Bundle-Version>1.0.0.qualifier</Bundle-Version>
-                            <!--TODO use Tycho plugin instead-->
-                            <Require-Bundle>org.eclipse.core.runtime,
-                                org.eclipse.ui.ide,
-                                org.eclipse.ui.console,
-                                org.talend.core,
-                                org.talend.core.runtime,
-                                org.talend.core.repository,
-                                org.talend.repository,
-                                org.talend.model,
-                                org.talend.repository,
-                                org.talend.designer.codegen,
-                                org.talend.commons.runtime,
-                                org.talend.core.repository,
-                                org.talend.designer.codegen
-                            </Require-Bundle>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
-        <pluginManagement>
+		
+		<pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -226,7 +240,129 @@
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>2.5</version>
                 </plugin>
+				 <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-p2-director-plugin</artifactId>
+                    <version>${tycho.version}</version>
+                    <configuration>
+                        <profile>profile</profile>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <finalName>bsb-talend-codegen-${project.version}</finalName>
+                    <archive>
+                        <manifestEntries>
+                            <Manifest-Version>1.0</Manifest-Version>
+                            <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                            <Bundle-Name>BuildJob Plug-in</Bundle-Name>
+                            <Bundle-SymbolicName>com.bsb.solife;singleton:=true</Bundle-SymbolicName>
+                            <Bundle-Version>1.0.0.qualifier</Bundle-Version>
+                            <!--TODO use Tycho plugin instead-->
+                            <Require-Bundle>org.eclipse.core.runtime,
+                                org.eclipse.ui.ide,
+                                org.eclipse.ui.console,
+                                org.talend.core,
+                                org.talend.core.runtime,
+                                org.talend.core.repository,
+                                org.talend.repository,
+                                org.talend.model,
+                                org.talend.repository,
+                                org.talend.designer.codegen,
+                                org.talend.commons.runtime,
+                                org.talend.core.repository,
+                                org.talend.designer.codegen
+                            </Require-Bundle>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+			 <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-packaging-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <strictVersions>${strictVersions}</strictVersions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-maven-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <extensions>true</extensions>
+            </plugin>  
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-versions-plugin</artifactId>
+                <version>${tycho.version}</version>
+            </plugin>			
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <executionEnvironmentDefault>JavaSE-1.7</executionEnvironmentDefault>
+                    <environments>
+                        <environment>
+                            <os>${osgi.os}</os>
+                            <ws>${osgi.ws}</ws>
+                            <arch>${osgi.arch}</arch>
+                        </environment>
+                    </environments>
+                    <filters>
+                        <!-- restrict version of a bundle -->
+                        <!--<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.ui.views.properties.tabbed</id>
+							<restrictTo>
+								<version>3.6.100.v20140519-0906</version>
+							</restrictTo>
+						</filter>-->
+                        <filter>
+                            <type>eclipse-plugin</type>
+                            <id>org.eclipse.jdt.core</id>
+                            <restrictTo>
+                                <version>3.10.0.xx-201411061335-e44-RELEASE</version>
+                            </restrictTo>
+                        </filter>
+
+                        <!-- example 2: remove all providers of the package javax.persistence except the bundle javax.persistence 
+				 <filter>
+					<type>java-package</type>
+					<id>javax.persistence</id>
+					<restrictTo>
+					   <type>eclipse-plugin</type>
+					   <id>javax.persistence</id>
+					</restrictTo>
+				 </filter>
+-->
+                        <!-- example 3: work around Equinox bug 348045 
+				 <filter>
+					<type>p2-installable-unit</type>
+					<id>org.eclipse.equinox.servletbridge.extensionbundle</id>
+					<removeAll />
+				 </filter>
+-->				 
+                    </filters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-compiler-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <compilerArgument>-warn:+discouraged,forbidden</compilerArgument>
+                    <compilerVersion>1.7</compilerVersion>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+      
     </build>
 </project>


### PR DESCRIPTION
After deleting my local Maven repository, I was not able to build the project. 

So I took some parts of the pom.xml file from talend to the pom.xml.

Now, mostly all dependencies are downloaded automatically. Only the org.talend.repository.jar must be installed manually (added this in the Readme.md and also a batch-file). 
